### PR TITLE
Ticker start time initialized in constructor. This leads to better estimates.

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -62,11 +62,6 @@ func (p Progress) Size() int64 {
 	return int64(p.size)
 }
 
-// Started gets whether the operation has started or not.
-func (p Progress) Started() bool {
-	return p.n > 0
-}
-
 // Complete gets whether the operation is complete or not.
 func (p Progress) Complete() bool {
 	return p.n >= p.size
@@ -108,7 +103,7 @@ func (p Progress) Estimated() time.Time {
 // If the context cancels the operation, the channel is closed.
 func NewTicker(ctx context.Context, counter Counter, size int64, d time.Duration) <-chan Progress {
 	var (
-		started time.Time
+		started = time.Now()
 		ch      = make(chan Progress)
 	)
 	go func() {
@@ -123,13 +118,9 @@ func NewTicker(ctx context.Context, counter Counter, size int64, d time.Duration
 					n:    float64(counter.N()),
 					size: float64(size),
 				}
-				if started.IsZero() {
-					if progress.Started() {
-						started = time.Now()
-					}
-				} else {
-					ratio := progress.n / progress.size
-					past := float64(time.Now().Sub(started))
+				ratio := progress.n / progress.size
+				past := float64(time.Now().Sub(started))
+				if progress.n > 0.0 {
 					total := time.Duration(past / ratio)
 					progress.estimated = started.Add(total)
 				}


### PR DESCRIPTION
**Observed:**

The time elapsed between the Ticker creation and the first tick is ignored in `progress.estimated` computation. This leads to : 
- unknown estimate at first tick ;
- skewed (very optimistic, and growing) subsequent estimates.

Here is a simulation of a very regular (predictable) `Reader` that reads 100 bytes every 100ms, for 6.2 seconds. The Ticker ticks every 400ms. The blue line is derived from `progress.Estimated()` :

![chart before](https://user-images.githubusercontent.com/13508141/34522126-7ef587a2-f091-11e7-8686-6739138ff9d6.png)

**Fix:**

Whether or not the correlated `Reader` or `Writer` actually starts work about at the same time as the call to `NewTicker`, it seems (to me) a sensible choice to consider the Ticker "started" as soon as its ticking timer is launched, i.e. at the Ticker creation.

In any case, there's no point (for the user) in creating a `Ticker` early (seconds before the work begins). We should assume it's created just when it's needed.

Same simulation, after code fix :

![chart after](https://user-images.githubusercontent.com/13508141/34522133-85520cec-f091-11e7-9ff7-86aaab53ff5c.png)

Here, the estimate is good from the start.